### PR TITLE
Add custom VS Code path to CopilotBridge

### DIFF
--- a/copilot_bridge.py
+++ b/copilot_bridge.py
@@ -2,13 +2,27 @@ import subprocess
 from pathlib import Path
 import uuid
 import logging
+import os
 
 class CopilotBridge:
     """Minimal interface to trigger GitHub Copilot via VS Code."""
 
-    def __init__(self, workspace: str | Path):
+    def __init__(self, workspace: str | Path, vscode_path: str | Path | None = None):
         self.workspace = Path(workspace)
         self.logger = logging.getLogger(__name__)
+        self.vscode_path = Path(vscode_path) if vscode_path else None
+
+        if self.vscode_path is None:
+            env_path = os.getenv("VSCODE_PATH")
+            if env_path:
+                self.vscode_path = Path(env_path)
+            else:
+                try:
+                    from matrix_ai_desktop_assistant import MatrixAIDesktopAssistant
+                    self.vscode_path = MatrixAIDesktopAssistant.find_vscode_path(None)
+                except Exception as e:
+                    self.logger.debug(f"find_vscode_path failed: {e}")
+                    self.vscode_path = None
 
     def ask(self, prompt: str) -> str:
         """Send a prompt to VS Code Copilot and return the response if possible."""
@@ -19,8 +33,10 @@ class CopilotBridge:
         # In a real implementation, a VS Code extension would read this file and
         # write the response to `<prompt_file>.out`. This is just a placeholder
         # to demonstrate how integration might be triggered without using an API.
+        vscode_cmd = str(self.vscode_path) if self.vscode_path else "code"
+
         try:
-            subprocess.run(["code", str(prompt_file)], check=True)
+            subprocess.run([vscode_cmd, str(prompt_file)], check=True)
         except FileNotFoundError:
             self.logger.error("VS Code executable not found in PATH")
             return "VS Code bulunamadı."


### PR DESCRIPTION
## Summary
- allow overriding the VS Code executable path for `CopilotBridge`
- use optional constructor argument, env var, or assistant helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684599db851c8332add57d00f7c5f728

## Summary by Sourcery

Enable custom VS Code executable path in CopilotBridge and apply the override when invoking the command

New Features:
- Allow supplying a custom VS Code path via CopilotBridge constructor
- Support VSCODE_PATH environment variable and auto-detect via MatrixAIDesktopAssistant if no path is provided

Enhancements:
- Use the resolved VS Code path instead of hard-coded "code" in subprocess calls
- Add debug logging when auto-detection of VS Code path fails