### PR TITLE
Add Copilot chat UI and cookie manager tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Copilot Lite Chat
+
+This repository includes a small desktop UI for interacting with your GitHub Copilot subscription. Ensure that Visual Studio Code and the Copilot extension are installed and that the `code` command is available in your system PATH.
+
+Start the chat interface with:
+
+```bash
+python copilot_chat_lite.py
+```

--- a/copilot_chat_lite.py
+++ b/copilot_chat_lite.py
@@ -1,0 +1,52 @@
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+from pathlib import Path
+from copilot_bridge import CopilotBridge
+
+
+class CopilotChatApp:
+    """Minimal desktop chat UI forwarding prompts to VS Code Copilot."""
+
+    def __init__(self, workspace: str | Path):
+        self.bridge = CopilotBridge(workspace)
+        self.root = tk.Tk()
+        self.root.title("Copilot Lite Chat")
+        self.history = ScrolledText(self.root, width=80, height=20, state="disabled")
+        self.history.pack(padx=10, pady=10)
+        entry_frame = tk.Frame(self.root)
+        entry_frame.pack(fill="x", padx=10)
+        self.input_var = tk.StringVar()
+        self.entry = tk.Entry(entry_frame, textvariable=self.input_var)
+        self.entry.pack(side="left", fill="x", expand=True)
+        send_btn = tk.Button(entry_frame, text="Send", command=self.send_message)
+        send_btn.pack(side="right", padx=5)
+        self.entry.bind("<Return>", lambda _event: self.send_message())
+
+    def append_history(self, prefix: str, message: str) -> None:
+        self.history.configure(state="normal")
+        self.history.insert(tk.END, f"{prefix}: {message}\n")
+        self.history.configure(state="disabled")
+        self.history.see(tk.END)
+
+    def send_message(self) -> None:
+        text = self.input_var.get().strip()
+        if not text:
+            return
+        self.append_history("You", text)
+        self.input_var.set("")
+        response = self.bridge.ask(text)
+        self.append_history("Copilot", response)
+
+    def run(self) -> None:
+        self.entry.focus()
+        self.root.mainloop()
+
+
+def main() -> None:
+    workspace = Path.cwd()
+    app = CopilotChatApp(workspace)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/github_workflows_auto-merge-codex.yml
+++ b/github_workflows_auto-merge-codex.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      
+
     steps:
       - name: Wait for checks
         uses: lewagon/wait-on-check-action@v1.3.1
@@ -42,6 +42,23 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
           allowed-conclusions: success,neutral,skipped
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests
+        run: pytest
           
       - name: Auto merge codex PRs  
         run: |

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -1,0 +1,53 @@
+import os
+import json
+from pathlib import Path
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from cookie_manager import CookieManager
+from cryptography.fernet import Fernet
+
+
+class DummyDriver:
+    def __init__(self):
+        self.cookies_added = []
+
+    def get_cookies(self):
+        return [{"name": "session", "value": "test"}]
+
+    def get(self, url: str):
+        pass
+
+    def add_cookie(self, cookie):
+        self.cookies_added.append(cookie)
+
+
+def test_save_and_load(tmp_path: Path):
+    pkl = tmp_path / "cookies.pkl"
+    jsn = tmp_path / "cookies.json"
+    cm = CookieManager(cookie_file=str(pkl), json_file=str(jsn))
+    driver = DummyDriver()
+    cm.save_cookies(driver)
+    assert pkl.exists() and jsn.exists()
+
+    driver2 = DummyDriver()
+    cm.load_cookies(driver2)
+    assert driver2.cookies_added[0]["name"] == "session"
+
+
+def test_encrypted_save_and_load(tmp_path: Path, monkeypatch):
+    pkl = tmp_path / "enc.pkl"
+    jsn = tmp_path / "enc.json"
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("COOKIE_ENCRYPTION_KEY", key)
+
+    cm = CookieManager(cookie_file=str(pkl), json_file=str(jsn))
+    driver = DummyDriver()
+    cm.save_cookies(driver)
+    assert pkl.exists() and jsn.exists()
+
+    driver2 = DummyDriver()
+    cm.load_cookies(driver2)
+    assert driver2.cookies_added[0]["value"] == "test"
+    monkeypatch.delenv("COOKIE_ENCRYPTION_KEY")


### PR DESCRIPTION
## Summary
- add `copilot_chat_lite.py` for a minimal Copilot chat interface
- document the new chat tool in `README.md`
- add unit tests for `CookieManager`
- run tests in the `auto-merge-codex` workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ce219780833294ca720eb9255ce4