### PR TITLE
Add VS Code path setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,24 @@ persistence and integrates with ChatGPT, VS Code, and GitHub.
 - GitHub API operations rely on the `requests` library
 
 Refer to `TODO.md` for remaining tasks.
+
+## VS Code Setup
+
+The assistant relies on the VS Code `code` command for Copilot integration.
+If VS Code is installed in a non‑standard location, you can override the
+executable path with the `VSCODE_PATH` environment variable.
+
+### Default locations
+
+| Platform | Path |
+| --- | --- |
+| **Windows** | `C:\Program Files\Microsoft VS Code\Code.exe` |
+| **macOS** | `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code` |
+| **Linux** | `/usr/share/code/bin/code` or simply `code` in your shell |
+
+### Copilot requirements
+
+Install the GitHub Copilot extension in VS Code and ensure the `code` command
+is available in your `PATH`. On Windows you can enable this via the
+`Shell Command: Install 'code' command in PATH` command from the Command
+Palette.


### PR DESCRIPTION
## Summary
- clarify how to specify the VS Code executable
- list default locations on Windows, macOS, and Linux
- document `VSCODE_PATH` env variable and Copilot requirements

## Testing
- `python -m py_compile matrix_ai_desktop_assistant.py copilot_bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_684599db70dc833282ee3ef73e17e4e6