### PR TITLE
Fix logging setup order

### DIFF
--- a/matrix_ai_desktop_assistant.py
+++ b/matrix_ai_desktop_assistant.py
@@ -63,11 +63,13 @@ class MatrixAIDesktopAssistant:
         self.vscode_process = None
         self.github_agent = None
         self.smolagents_git = None        # SmolAgents Git entegrasyonu
-        self.chatgpt_stealth = None        # ChatGPT Stealth entegrasyonu        # Konfigürasyon
-        self.config = self.load_config()
-        
+        self.chatgpt_stealth = None        # ChatGPT Stealth entegrasyonu
+
         # Logging sistemi
         self.setup_logging()
+
+        # Konfigürasyon
+        self.config = self.load_config()
         
         # GUI başlatma
         self.init_gui()


### PR DESCRIPTION
## Summary
- ensure `setup_logging()` runs before loading config

## Testing
- `python3 -m py_compile matrix_ai_desktop_assistant.py`

------
https://chatgpt.com/codex/tasks/task_e_684599d08e3883329cc521a612a4d4e6