### PR TITLE
Improve VS Code detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ persistence and integrates with ChatGPT, VS Code, and GitHub.
 - Optional Chrome extension loading via `CHROME_EXTENSION_PATH`
 - GUI fallback between PySide6, CustomTkinter, or terminal
 - VS Code Copilot integration via `CopilotBridge` without direct API usage
+- Auto-detects VS Code binary on Windows, Linux (`/usr/bin/code`, `/snap/bin/code`) and macOS (`/Applications/Visual Studio Code.app/...`)
+- Override detection with the `VSCODE_PATH` environment variable for custom installations
 - Commit message generation with HuggingFace `smolagents` when `USE_SMOLAGENTS` is enabled
 - GitHub API operations rely on the `requests` library
 

--- a/matrix_ai_desktop_assistant.py
+++ b/matrix_ai_desktop_assistant.py
@@ -633,10 +633,23 @@ Bir proje fikrinizi anlatın veya komut verin!
     
     def find_vscode_path(self):
         """VS Code yolunu bul"""
+        # Kullanıcı özel bir kurulum dizini belirttiyse onu kullan
+        env_path = os.getenv("VSCODE_PATH")
+        if env_path and os.path.exists(env_path):
+            return env_path
+
         possible_paths = [
+            # Windows
             "C:\\Program Files\\Microsoft VS Code\\Code.exe",
             "C:\\Program Files (x86)\\Microsoft VS Code\\Code.exe",
-            "C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe"
+            "C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe",
+            # Linux
+            "/usr/bin/code",
+            "/usr/local/bin/code",
+            "/snap/bin/code",
+            # macOS
+            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+            "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"
         ]
         
         for path in possible_paths:


### PR DESCRIPTION
## Summary
- detect Visual Studio Code automatically on Linux and macOS
- allow overriding the VS Code path with `VSCODE_PATH`
- document how VS Code discovery works

## Testing
- `python -m py_compile matrix_ai_desktop_assistant.py`
- `python -m py_compile browser_agent_stealth.py matrix_ai_chatgpt_stealth_integration.py matrix_ai_intent_detector.py smolagents_git_power.py universal_bypass_launcher.py universal_chrome_bypass.py copilot_bridge.py cookie_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_684599d3e088833291c604f63d2cc698